### PR TITLE
apply password age settings to regular users

### DIFF
--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -233,6 +233,12 @@ We know that this is the case on Raspberry Pi.
 - `os_chmod_rootuser_home_folder`
   - Default: `true`
   - Description: Set to `false` to disable "chmod 700" of root's home folder
+- `os_user_pw_ageing`
+  - Default: `true`
+  - Description: Set to false to disable password age enforcement on existing users
+- `os_users_without_password_ageing`
+  - Default: `[]`
+  - Description: List of users, where password ageing should not enforced
 - `os_rootuser_pw_ageing`
   - Default: `false`
   - Description: Set to true to enforce password age settings for root user(s)

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -25,7 +25,11 @@ os_security_users_allow: []
 os_ignore_home_folder_users: ['lost+found']
 
 # Set to false to disable password age enforcement on existing users
+os_user_pw_ageing: true
 os_rootuser_pw_ageing: false
+
+#List of users, where password ageing should not enforced
+os_users_without_password_ageing: []
 
 # When enabled and there are multiple users with UID=0, only "root" will be kept. Others will be deleted.
 os_remove_additional_root_users: false

--- a/roles/os_hardening/tasks/user_accounts.yml
+++ b/roles/os_hardening/tasks/user_accounts.yml
@@ -40,6 +40,26 @@
     - root_users|length > 1
     - item != "root"
 
+- name: extract regular (non-system, non-root) accounts from local user database
+  loop: "{{ getent_passwd.keys()|list }}"
+  when:
+    - getent_passwd[item][1]|int >= os_auth_uid_min|int
+    - getent_passwd[item][1]|int <= os_auth_uid_max|int
+    - item is not in os_always_ignore_users     # skip users from "os_always_ignore_users" list (taken from role "vars")
+    - item is not in os_ignore_users            # skip users from "os_ignore_users"        list (taken from role "defaults")
+  set_fact:
+    regular_users: "{{ regular_users|default([]) + [item] }}"
+
+- name: set password ageing for exisiting regular (non-system, non-root) accounts
+  user:
+    name: "{{ item }}"
+    password_expire_min: "{{ os_auth_pw_min_age }}"
+    password_expire_max: "{{ os_auth_pw_max_age }}"
+  loop: "{{ regular_users }}"
+  when:
+    - os_user_pw_ageing
+    - item not in os_users_without_password_ageing
+
 - name: Get UID_MIN from login.defs
   shell: awk '/^\s*UID_MIN\s*([0-9]*).*?$/ {print $2}' /etc/login.defs
   args:


### PR DESCRIPTION
* fixes #570
* depends on #579, by re-using the "getent_passwd" results from the task "Read local linux user database"
* you might want to change the defaults I used for new varaibles
* tested on RHEL8 only
